### PR TITLE
chore: rename 'jupiter' package in 'reactive'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>2.1</gravitee-bom.version>
         <gravitee-resource-api.version>1.0.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.44.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.18</gravitee-gateway-api.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/io/gravitee/resource/cache/api/CacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/api/CacheResource.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.resource.cache.api;
 
-import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
-import io.gravitee.gateway.jupiter.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
 import io.gravitee.resource.api.AbstractConfigurableResource;
 import io.gravitee.resource.api.ResourceConfiguration;
 


### PR DESCRIPTION
related to APIM-718
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-apim-718-rename-v4-terms-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-provider-api/1.4.0-apim-718-rename-v4-terms-SNAPSHOT/gravitee-resource-cache-provider-api-1.4.0-apim-718-rename-v4-terms-SNAPSHOT.zip)
  <!-- Version placeholder end -->
