### PR TITLE
chore: update circleCI config to release alpha version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_lib-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-chore-update-circleci-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-provider-api/1.4.0-chore-update-circleci-SNAPSHOT/gravitee-resource-cache-provider-api-1.4.0-chore-update-circleci-SNAPSHOT.zip)
  <!-- Version placeholder end -->
