### PR TITLE
use new ExecutionContext

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,13 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.1
+    gravitee: gravitee-io/gravitee@4.7.2
+
+parameters:
+    jobCacheVersion:
+        description: CircleCI cache version
+        type: string
+        default: "0"
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -13,7 +19,7 @@ workflows:
         when:
             not: << pipeline.git.tag >>
         jobs:
-            - gravitee/setup_lib-build-config:
+            - gravitee/setup_plugin-build-config:
                   filters:
                       tags:
                           ignore:
@@ -25,7 +31,7 @@ workflows:
                 pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
-            - gravitee/setup_lib-release-config:
+            - gravitee/setup_plugin-release-config:
                   filters:
                       branches:
                           ignore:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,14 @@
-**Issue**
+## Issue
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/APIM-XXX
 
-**Description**
+## Description
 
 A small description of what you did in that PR.
 
-**Additional context**
+## Additional context
 
 <!-- Add any other context about the PR here -->
 <!-- It can be links to other PRs or docs or drawing -->
 <!-- Or reproduction steps in case of bug fix -->
+

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,19 +24,19 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>22.2.2</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
     <artifactId>gravitee-resource-cache-provider-api</artifactId>
-    <version>1.4.0</version>
+    <version>2.0.0-APIM-7417-use-new-executioncontext-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Resource - Cache Provider API</name>
 
     <properties>
-        <gravitee-bom.version>4.0.0</gravitee-bom.version>
-        <gravitee-resource-api.version>1.0.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>8.1.16</gravitee-bom.version>
+        <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
+        <gravitee-gateway-api.version>3.9.0-alpha.11</gravitee-gateway-api.version>
     </properties>
 
     <dependencyManagement>
@@ -68,34 +68,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <additionalJOption>-Xdoclint:none</additionalJOption>
-                    <source>8</source>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/main/java/io/gravitee/resource/cache/api/Cache.java
+++ b/src/main/java/io/gravitee/resource/cache/api/Cache.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/cache/api/CacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/api/CacheResource.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/cache/api/CacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/api/CacheResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.resource.cache.api;
 
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.resource.api.AbstractConfigurableResource;
 import io.gravitee.resource.api.ResourceConfiguration;
 
@@ -27,7 +28,13 @@ public abstract class CacheResource<C extends ResourceConfiguration> extends Abs
 
     public abstract Cache getCache(io.gravitee.gateway.api.ExecutionContext ctx);
 
+    /**
+     * @deprecated use <code>getCache({@link BaseExecutionContext})</code> instead
+     */
+    @Deprecated(forRemoval = true)
     public abstract Cache getCache(GenericExecutionContext ctx);
+
+    public abstract Cache getCache(BaseExecutionContext ctx);
 
     public String keySeparator() {
         return "_";

--- a/src/main/java/io/gravitee/resource/cache/api/Element.java
+++ b/src/main/java/io/gravitee/resource/cache/api/Element.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7417

**Description**

 - Bump dependencies.
 - add a `getCache(BaseExecutionContext ctx)` method and deprecate the one using `GenericExecutionContext`

BREAKING CHANGE: requires gravitee-gateway-api 3.9.0+

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-APIM-7417-use-new-executioncontext-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-provider-api/2.0.0-APIM-7417-use-new-executioncontext-SNAPSHOT/gravitee-resource-cache-provider-api-2.0.0-APIM-7417-use-new-executioncontext-SNAPSHOT.zip)
  <!-- Version placeholder end -->
