### PR TITLE
feat(cache): add async methods to Cache interface

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/api/Cache.java
+++ b/src/main/java/io/gravitee/resource/cache/api/Cache.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.resource.cache.api;
 
+import io.vertx.core.Future;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
@@ -31,4 +33,39 @@ public interface Cache {
     void evict(Object key);
 
     void clear();
+
+    default Future<Element> getAsync(Object key) {
+        try {
+            return Future.succeededFuture(get(key));
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    default Future<Void> putAsync(Element element) {
+        try {
+            put(element);
+            return Future.succeededFuture();
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    default Future<Void> evictAsync(Object key) {
+        try {
+            evict(key);
+            return Future.succeededFuture();
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    default Future<Void> clearAsync() {
+        try {
+            clear();
+            return Future.succeededFuture();
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add async overloads to `Cache` interface using Vert.x `Handler<AsyncResult<T>>` pattern: `get`, `put`, `evict`, `clear`
- Default implementations wrap blocking calls with try/catch, delegating to `Future.succeededFuture` / `Future.failedFuture`
- No new dependencies needed — `vertx-core` is already provided transitively via `gravitee-gateway-api`
- Fully backward-compatible: existing `Cache` implementations continue to work unchanged

Ref: APIM-13554

## Test plan
- [x] `mvn test` passes (BUILD SUCCESS)
- [ ] Validate in-memory cache resource works with default async methods (Story 4 / APIM-13555)
- [ ] Validate Redis cache resource overrides async methods with native Vert.x calls (Story 5 / APIM-13556)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-feat-async-cache-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-provider-api/2.1.0-feat-async-cache-api-SNAPSHOT/gravitee-resource-cache-provider-api-2.1.0-feat-async-cache-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
