### PR TITLE
feat(cache): add getBinaryAsync/putBinaryAsync to Cache (APIM-13628)

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/api/Cache.java
+++ b/src/main/java/io/gravitee/resource/cache/api/Cache.java
@@ -68,4 +68,48 @@ public interface Cache {
             return Future.failedFuture(e);
         }
     }
+
+    /**
+     * Read a value preserving binary fidelity.
+     * <p>
+     * Implementations that distinguish between text and binary storage (e.g. Redis) MUST override this
+     * method and return the value as a {@code byte[]} on the {@link Element#value()} of the returned
+     * element. Backends that do not distinguish (e.g. in-memory) may rely on the default delegation
+     * to {@link #getAsync(Object)}.
+     * <p>
+     * <strong>Backends that store text-typed values and do not override this method will return an
+     * {@link Element} whose {@link Element#value()} is the backend's native type</strong> (e.g.
+     * {@code String}), not {@code byte[]}. Callers must be prepared to handle this — typically by
+     * version-sniffing the payload (see the {@code gravitee-policy-cache} {@code CacheFrame.isLegacyFormat}
+     * pattern) rather than blindly casting to {@code byte[]}.
+     *
+     * @param key the cache key
+     * @return a future completing with the element, or {@code null} if absent
+     * @since 2.2.0
+     */
+    default Future<Element> getBinaryAsync(Object key) {
+        return getAsync(key);
+    }
+
+    /**
+     * Write a value preserving binary fidelity.
+     * <p>
+     * The {@link Element#value()} is expected to be a {@code byte[]}. Implementations that distinguish
+     * between text and binary storage (e.g. Redis) MUST override this method and persist the raw bytes
+     * without character-encoding transformations. Backends that do not distinguish may rely on the
+     * default delegation to {@link #putAsync(Element)}.
+     * <p>
+     * <strong>If the backend has not overridden this method, the default delegation to
+     * {@link #putAsync(Element)} may fail at runtime</strong> (e.g. with {@code ClassCastException})
+     * when the underlying implementation expects a {@code String}-typed value. Operators upgrading
+     * a cache backend across this API version should ensure the backend implements this method
+     * before routing binary writes to it.
+     *
+     * @param element the element to store; {@code element.value()} must be a {@code byte[]}
+     * @return a future completing when the write is done
+     * @since 2.2.0
+     */
+    default Future<Void> putBinaryAsync(Element element) {
+        return putAsync(element);
+    }
 }


### PR DESCRIPTION
## Summary

Adds two new default methods on the `Cache` interface to allow cache backends to expose a binary-safe path for `byte[]` values, without breaking any existing consumer that uses the `String`-based `getAsync`/`putAsync`.

- `default Future<Element> getBinaryAsync(Object key)` — delegates to `getAsync` by default.
- `default Future<Void> putBinaryAsync(Element element)` — delegates to `putAsync` by default.

Backends that distinguish text from binary storage (Redis) override these to use binary-safe transport. Backends that don't (in-memory `NodeCacheDelegate`) inherit the default and work unchanged.

## Why

Per [APIM-13628](https://gravitee.atlassian.net/browse/APIM-13628), `gravitee-policy-cache` is moving from a JSON-envelope-with-Base64 cache value format to a compact binary frame. The new policy emits `byte[]` payloads. The current `Cache` contract is effectively `String`-typed (`RedisDelegate` does `(String) element.value()`), so widening to `byte[]` without breaking existing consumers (e.g. `gravitee-policy-oauth2`, which does `(String) element.value()`) requires an additive method pair.

## Jira

[APIM-13628](https://gravitee.atlassian.net/browse/APIM-13628)

## Sibling PRs

- gravitee-resource-cache-redis — overrides these methods with binary-safe Vert.x Redis send/receive: https://github.com/gravitee-io/gravitee-resource-cache-redis/pull/84
- gravitee-policy-cache — calls the new methods instead of `getAsync`/`putAsync`: https://github.com/gravitee-io/gravitee-policy-cache/pull/104

## Test plan

- [x] Compiles cleanly against existing tests (no test sources in this module).
- [x] Default impls are pure delegation to already-tested methods.
- [ ] Once Redis override merges and the new policy is wired, verify end-to-end through a real gateway + Redis (done locally; see APIM-13628 comments).

## Release ordering

This PR must be merged + released **first** (as `2.2.0`, additive). The Redis override and the policy follow, gated on the BOM being updated to reference the new release.

[APIM-13628]: https://gravitee.atlassian.net/browse/APIM-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-13628]: https://gravitee.atlassian.net/browse/APIM-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-feat-APIM-13628-binary-methods-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-provider-api/2.2.0-feat-APIM-13628-binary-methods-SNAPSHOT/gravitee-resource-cache-provider-api-2.2.0-feat-APIM-13628-binary-methods-SNAPSHOT.zip)
  <!-- Version placeholder end -->
